### PR TITLE
Test out-of-sync PR workflows scenarios

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -11,8 +11,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Android SDK versions
-        shell: bash
-        run: ./android-sdk-list.sh
+        run: bash ./android-sdk-list.sh
+
+      - name: Run branch script
+        if: always()
+        run: bash ./hello-from-branch.sh
 
       - name: Build args
         id: build-args

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Android SDK versions
         shell: bash

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Github Actions how to supreme
+# Github Actions how to
 
 Various patterns usable with Github Actions.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Github Actions how to
+# Github Actions how to supreme
 
 Various patterns usable with Github Actions.
 

--- a/hello-from-branch.sh
+++ b/hello-from-branch.sh
@@ -1,0 +1,1 @@
+echo hello from branch


### PR DESCRIPTION
This PR is testing the Github Actions behavior of always using the base branch version of workflows files, independently from the `actions/checkout` you're using.

## Base branch context

The commit https://github.com/pgreze/github-actions-howto/commit/df7bc3f8edd412dd515b4f06737d1f339d903462 in `main` added several new behaviors to run scripts from .github/{actions,scripts} as well as root dir, and renamed a workflow.

## This PR context

The current PR branch is not including the main 🔝 commit + we're using checkout with `ref: ${{ github.event.pull_request.head.sha }}` to fetch the branch content only.
This is changing the GHA default behavior where the default `ref` is a merge of your branch latest commit merged with the latest commit from your base branch 🪄

As you can see in the following workflow for this branch, main's workflows were used but not used scripts, leading to failure:
https://github.com/pgreze/github-actions-howto/actions/runs/10554769908/job/29237165472?pr=17
Except the renamed workflow, all other failed...
![image](https://github.com/user-attachments/assets/e03af152-b4ad-4705-bf31-4c7990256fa4)

## 2nd PR targeting this branch

I wanted to test if a PR targeting another PR was using `main branch` workflows or the `base branch` one.
In this case, only the custom script added in the base branch was tried, and so `main` changes were not included:
![image](https://github.com/user-attachments/assets/5d569954-9a85-477f-afd3-24dbb1132469)
